### PR TITLE
Suggested Docs Improvements

### DIFF
--- a/api.md
+++ b/api.md
@@ -96,7 +96,7 @@ This object includes all the information about the request for RESTful API. Requ
 
 ### `ApiResponse` Object
 
-This object includes to response object to be returned by the RESTful API. See the sample JSON for a GET request.
+This object includes the response object to be returned by the RESTful API. See the sample JSON for a GET request.
 
 ```json
 {
@@ -143,7 +143,7 @@ publicApi.patch("/:id", async (event) => {
 
 ## Serving files through API
 
-To send files stored at Ampt Storage, developers can use `getDownloadUrl` function.
+To send files stored at Ampt Storage, developers can use the `getDownloadUrl` function.
 
 ```javascript
 const files = api("files").router("/files", { path: v.string() }, auth);
@@ -191,7 +191,7 @@ function cors(event: any) {
 const publicApi = api("public").router("/users", { id: v.string() }, cors);
 ```
 
-If you want to only allow CORS in development (personal environments), you can use the INSTANCE_TYPE param to set it dynamically:
+If you want to only allow CORS in development (personal environments), you can use the ENVIRONMENT_TYPE param to set it dynamically:
 This closes cross origin requests on stage environments, for better security.
 
 ```javascript

--- a/cdn.md
+++ b/cdn.md
@@ -22,11 +22,11 @@ Avoid having static pages that have corresponding API routes. For example, if yo
 
 ## Static asset caching
 
-Static assets are automatically cached in Cloud's Content Delivery Network (CDN) in edge locations around the world so download speeds will be very fast.
+Static assets are automatically cached in Ampt's Content Delivery Network (CDN) in edge locations around the world so download speeds will be very fast.
 
 Caching works differently in "stage" and "personal" instances.
 
-In stage instances, static assets are cached in the CDN for up to 24 hours. Responses will include a `Cache-Control` header that tells the CDN to cache the asset for 24 hours, and tells the browser to cache the asset and "revalidate" it before using it. When you deploy a new version of your application, Cloud will automatically clear the CDN cache so your users will get the latest version when they refresh the browser.
+In stage instances, static assets are cached in the CDN for up to 24 hours. Responses will include a `Cache-Control` header that tells the CDN to cache the asset for 24 hours, and tells the browser to cache the asset and "revalidate" it before using it. When you deploy a new version of your application, Ampt will automatically clear the CDN cache so your users will get the latest version when they refresh the browser.
 
 Caching is disabled in developer sandboxes so you can update your assets and immediately see the latest version when you reload your browser. Responses for static assets in your developer sandbox will include a `Cache-Control` header that disables caching in the CDN, and an additional `X-Cache-Control` header that shows you the value of the header that will be used in stage instances.
 

--- a/data.md
+++ b/data.md
@@ -28,7 +28,7 @@ api("my-api")
 
 ## Setting Items
 
-Setting data can be accomplished using the `set` method. You provide a **key** as the first argument and a **value** (either a string, boolean, number, array, or object) as the second parameter. Keys are case sensitive and can be `string` up to 256 bytes each and can contain any valid utf8 character including spaces. By default, the `set` command will return the updated item.
+Setting data can be accomplished using the `set` method. You provide a **key** as the first argument and a **value** (either a string, boolean, number, array, or object) as the second parameter. Keys are case sensitive, can be a `string` of up to 256 bytes each, and can contain any valid utf8 character including spaces. By default, the `set` command will return the updated item.
 
 ```javascript
 await data.set("foo", "bar");
@@ -72,7 +72,7 @@ let results = await data.set(
 	[
 		{ key: "key1", value: "string value" },
 		{ key: "someOtherKey", value: 123, ttl: 1000 },
-		{ key: "namespacedKey:keyX", value: { foo: "bar" }, label1: "foo:baz }
+		{ key: "namespacedKey:keyX", value: { foo: "bar" }, label1: "foo:baz" }
 	],
 	{ overwrite: true }
 );
@@ -329,7 +329,7 @@ data.on("*", async (event) => {
 });
 ```
 
-It's possible for more than one handler to be called for a given change to a data item, in which case the handlers are called in the order they were defined. In the example above, the first handler will always be called the before the second handler when an item is created or updated, and only the second handler will be called when an item is deleted.
+It's possible for more than one handler to be called for a given change to a data item, in which case the handlers are called in the order they were defined. In the example above, the first handler will always be called before the second handler when an item is created or updated, and only the second handler will be called when an item is deleted.
 
 ### Event format
 
@@ -377,7 +377,7 @@ data.on("created:order_*:item_*", (event) => {
 
 ### Event ordering
 
-Data events are processed in the order that the changes were applied to your data items, within a item namespace. It's possible for multiple handlers to be invoked in parallel, but for different namespaces.
+Data events are processed in the order that the changes were applied to your data items, within an item namespace. It's possible for multiple handlers to be invoked in parallel, but for different namespaces.
 
 ### Handling errors
 

--- a/environments.md
+++ b/environments.md
@@ -3,7 +3,7 @@ title: Apps & Environments
 description: Ampt allows you to organize workloads into apps with isolated environments.
 ---
 
-Ampt's isolation model lets developers rapidly iterate on applications without needing to share services or worry about resource contention. Whether your a solo developer or a team collaborating with colleagues, Ampt reduces the development feedback loop and accelerates the path to production without sacrificing standard CI/CD and testing processes.
+Ampt's isolation model lets developers rapidly iterate on applications without needing to share services or worry about resource contention. Whether you're a solo developer or a team collaborating with colleagues, Ampt reduces the development feedback loop and accelerates the path to production without sacrificing standard CI/CD and testing processes.
 
 ## Apps
 
@@ -11,7 +11,7 @@ Ampt allows you to build **apps** within your **organization**. **Apps** are ext
 
 ## Environments
 
-The actual code and resources for an **app** run in isolated **environmemts**. Each **environment** contains its own set of independent resources including separate copies of data and storage. The resources within each **environment** are identical, so you can ensure that your application will run the same way across all phases of development.
+The actual code and resources for an **app** run in isolated **environments**. Each **environment** contains its own set of independent resources including separate copies of data and storage. The resources within each **environment** are identical, so you can ensure that your application will run the same way across all phases of development.
 
 Ampt's isolation model and rapid provisioning technology uses **environment "types"** to enable incredibly powerful workflows.
 

--- a/parameters.md
+++ b/parameters.md
@@ -3,7 +3,7 @@ title: Parameters
 description: Built-in parameter store to keep secrets encrpyted and available only during runtime.
 ---
 
-Ampt's built-in parameter store allows developers to store the parameters in a secure way, and to use them programmatically with `params` interface of Ampt SDK. All the parameters are encrypted both at transit and at rest and only decrypted during runtime.
+Ampt's built-in parameter store allows developers to store the parameters in a secure way, and to use them programmatically with the `params` interface of Ampt SDK. All the parameters are encrypted both at transit and at rest and only decrypted during runtime.
 
 !!! note
 When you modify a parameter value in the Ampt Dashboard, the changes are instantly applied to all running environments that require the parameter. No restart or anything required to flush the parameters.
@@ -11,7 +11,7 @@ When you modify a parameter value in the Ampt Dashboard, the changes are instant
 
 ## Parameter Scopes
 
-Some parameters apply to all apps within an organization, while others might be specific to a particular project or application. Additionally, an application will almost probably use a different value of a parameter in the production and development.
+Some parameters apply to all apps within an organization, while others might be specific to a particular project or application. Additionally, an application will probably use a different value of a parameter in production and development.
 
 **Organization-level parameters** are defined under "Organization Settings" in the Ampt Dashboard. Every environment of every app will inherit those parameters automatically. Organization-level parameters can be overridden at the app and environment levels. For example, you can define an API key to be used for a third-party vendor as `THIRD_PARTY_API_KEY` and you can override this parameter for the production environment (permanent environments will be available soon).
 

--- a/runtime.md
+++ b/runtime.md
@@ -11,4 +11,4 @@ We'll be providing more information about the Ampt Universal Runtime soon.
 - Automatically transpiles TypeScript with source maps and supports tsconfig paths
 - Reloads code in dev mode
 - WebAPI polyfilled
-- Adapts requests from various event sources in to consistent format (e.g. fetch)
+- Adapts requests from various event sources into a consistent format (e.g. fetch)


### PR DESCRIPTION
While reading through all of the Ampt documentation today, I thought it might be helpful to take notes, mark changes I might make, and open them as a PR. Almost all of the changes are grammatical, but some are syntax errors in example code.

These are all suggestions, and some of them I am not sure about - so take or leave whichever bits you'd like. For example, on the CDN page, 'Cloud' is referenced twice when I think it should be referencing 'Ampt' instead. I don't know for sure if that's incorrect, though.

Love the docs in general. Easy to follow, great examples, and I especially like when you get into the philosophy of *why* you might want to do things this way. Great work, so excited for the future of this!