### PR TITLE
sveltekit.md: replace svelte with seveltekit

### DIFF
--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -3,7 +3,7 @@ title: SvelteKit
 description: Integrate with SvelteKit for a full-stack development experience.
 ---
 
-You can integrate your Svelte application with Ampt and achieve a full stack development experience for your applications. Follow the below steps to integrate your Svelte application with Ampt.
+You can integrate your SvelteKit application with Ampt and achieve a full stack development experience for your applications. Follow the below steps to integrate your SvelteKit application with Ampt.
 
 Install the `@ampt/sveltekit` adapter:
 
@@ -17,7 +17,7 @@ or run this when you’re in the interactive shell:
 > install @ampt/sveltekit
 ```
 
-Create an `index.js` or `index.ts` file that imports the Ampt Svelte server wrapper:
+Create an `index.js` or `index.ts` file that imports the Ampt SvelteKit server wrapper:
 
 ```javascript header=false
 import "@ampt/sveltekit/server";


### PR DESCRIPTION
In my opinion these "Svelte" should be replaced with "SvelteKit" also. The only "Svelte" left is now in Svelte config context, where the file has a name of "svelte.config.js", so this seems fine for me.

FYI: @benminer 