### PR TITLE
chore: update docs to avoid using `type: "module"`

### DIFF
--- a/frameworks/next.md
+++ b/frameworks/next.md
@@ -40,7 +40,6 @@ This is an example of what your `package.json` should look like::
 {
   "name": "my-nextjs-app",
   "main": "index.js",
-  "type": "module",
   "scripts": {
     "build": "next build",
     "ampt:build": "ampt-next build",
@@ -58,7 +57,7 @@ Add the file `index.js` to the root of your project, and add the following code:
 ```javascript header=false
 // index.js
 
-import "@ampt/nextjs/entrypoint";
+require("@ampt/nextjs/entrypoint");
 ```
 
 This adds the Next.js server and image optimization to your application's entrypoint.


### PR DESCRIPTION
(Verified with a brand new Next.js project created via `npx create-next-app`).

`create-next-app` by default does not use the `"type": "module"` (assuming that the default options were selected):
<img width="602" alt="Screenshot 2023-10-14 at 17 35 20" src="https://github.com/getampt/docs/assets/16646517/8863732c-4c85-436e-b947-f7a249a3bf55">

While it is possible to use ESM modules in Next (which would require changing `next.config.js` to `next.config.mjs`, as well as other changes, see docs: https://nextjs.org/docs/pages/api-reference/next-config-js), IMHO Ampt docs should default to the most commonly used behaviour.

Customers who are just getting started with Ampt (and/or Next) are likely to be confused. Changes in this PR are also in line with the [Ampt Next.js template](https://github.com/ampt-templates/nextjs/blob/main/package.json).