### PR TITLE
chore: update astro docs to remove svelte reference

### DIFF
--- a/frameworks/astro.md
+++ b/frameworks/astro.md
@@ -43,12 +43,11 @@ Add the ampt integration to your `astro.config.mjs` file:
 
 import { defineConfig } from "astro/config";
 import ampt from "@ampt/astro";
-import svelte from "@astrojs/svelte";
 
 // https://astro.build/config
 export default defineConfig({
   output: "server",
-  integrations: [ampt(), svelte()],
+  integrations: [ampt(), /* other integrations */],
 });
 ```
 


### PR DESCRIPTION
Svelte is not required to run an Astro app and `import svelte from "@astrojs/svelte";` gave me a bit of a pause.

Took the liberty of replacing it with a comment indicating that you can use other integrations in addition to `ampt()`, let me know if that works for you!