### PR TITLE
chore: add url to jimp documentation

### DIFF
--- a/http.md
+++ b/http.md
@@ -100,10 +100,11 @@ You must have Response Streaming enabled in your app's settings to raise the tim
 
 Although static assets can be read from the file system in sandboxes, they are not stored in the file system when your application is deployed to a stage. We recommend that you _not_ read static assets from your application. Any files your application needs at runtime should be stored within your project outside the "static" folder. For example, you can create an "assets" folder to hold images or html files that your application can then read from the file system at runtime.
 
-If your application still needs to read static files, it is possible to do so using the `http.readStaticFile(relativePath)` method. This will return a `ReadableStream` instance that you can use to read the file. For example to read an image in your project that is in "static/images/image.jpeg" and process it using `jimp` you could use:
+If your application still needs to read static files, it is possible to do so using the `http.readStaticFile(relativePath)` method. This will return a `ReadableStream` instance that you can use to read the file. For example to read an image in your project that is in "static/images/image.jpeg" and process it using [`jimp`](https://github.com/jimp-dev/jimp) you could use:
 
 ```javascript
 import { http } from "@ampt/sdk";
+import Jimp from "jimp";
 
 const stream = await http.readStaticFile("images/image.jpeg");
 const chunks: Uint8Array[] = [];


### PR DESCRIPTION
Since jimp is something that not every reader may be aware of, I'd say it's better to link to its docs. This PR also edits the example code to include an import statement.