### PR TITLE
Import SvelteKit adapter from the correct module

### DIFF
--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -31,7 +31,7 @@ For any static assets (such as images) you will need to add a folder to your pro
 
 ```javascript header=false
 import { vitePreprocess } from "@js/kit/vite";
-import adapter from "@ampt/kit";
+import adapter from "@ampt/sveltekit";
 
 /** @type {import('@js/kit').Config} */
 const config = {


### PR DESCRIPTION
The SvelteKit adapter lives under `@ampt/sveltekit`, but the docs specify importing it from `@ampt/kit` – which does not exist.

This PR changes that one line of the docs to specify importing from `@ampt/sveltekit` instead.