### PR TITLE
fix: Improve SPA fallback documentation for client-side routing

### DIFF
--- a/frameworks/spas.md
+++ b/frameworks/spas.md
@@ -36,9 +36,21 @@ For example, if a large React dependency like `@mui/material` is defined in `dep
   },
 ```
 
-## Returning index.html for all paths
+## Configuring Client-Side Routing
 
-SPAs typically serve a single `index.html` for all paths. See the [HTTP interface documentation](/docs/http/#single-page-applications-spas) for details on how to do this. Using express, you would do the following:
+Single-page applications (SPAs) use client-side routing to navigate between pages without full page reloads. When a user navigates to a route like `/about` or `/products/123`, the SPA's JavaScript router handles the navigation and updates the page content dynamically.
+
+**However, there's a critical problem**: If a user refreshes the page or shares a deep link (like `https://yourapp.ampt.app/products/123`), the browser will request that exact path from your server. Without proper configuration, your server will return a **404 error** because it doesn't have a route handler for that path—only your client-side JavaScript router knows about it.
+
+### The Solution: SPA Fallback Pattern
+
+To make client-side routing work correctly, you need to configure your server to return `index.html` for **all paths** that aren't API routes or static assets. This allows your SPA's JavaScript to load and take over routing.
+
+!!! caution
+**This configuration is required for SPAs with client-side routing.** Without it, users will see 404 errors when refreshing pages or accessing deep links directly.
+!!!
+
+Here's how to implement the SPA fallback pattern using Express:
 
 ```javascript
 import { http } from "@ampt/sdk"
@@ -46,12 +58,27 @@ import express from "express"
 
 const app = express()
 
+// IMPORTANT: Define API routes FIRST, before the fallback
 app.use('/api', ...)
 
-app.use((req, res) => {
-  // Return "static/index.html"
+// SPA fallback: Return index.html for all other paths
+app.use(async (req, res) => {
   res.status(200).set('Content-Type', 'text/html')
   const stream = await http.node.readStaticFile("index.html")
   return stream.pipe(res)
 })
+
+http.node.use(app)
 ```
+
+!!! note
+**Order matters!** The SPA fallback must come **after** all your API routes. Otherwise, API requests will receive `index.html` instead of your API responses.
+!!!
+
+This pattern ensures:
+- Your SPA loads correctly for any route (e.g., `/`, `/about`, `/products/123`)
+- Users can refresh the page without getting 404 errors
+- Deep links work properly when shared
+- Your client-side router takes over once the page loads
+
+For more details, see the [HTTP interface documentation](/docs/http/#single-page-applications-spas).

--- a/http.md
+++ b/http.md
@@ -144,6 +144,14 @@ app.use(async (req, res) => {
 
 Single-Page Applications (SPAs) are applications that load a single HTML page and dynamically update that page as the user interacts with the application. SPAs are typically built using a JavaScript framework such as React, Vue, or Angular.
 
+### The SPA Routing Problem
+
+SPAs use client-side routing to navigate between pages. When a user visits a route like `/products/123`, your SPA's JavaScript router handles it. But if the user refreshes the page or shares that URL, the browser makes a direct request to your server for `/products/123`. Without proper configuration, this results in a **404 error** because your server doesn't have a route handler for that path.
+
+### The Solution: Serve index.html for All Paths
+
+To fix this, configure your server to return `index.html` for all paths that aren't API routes or static assets. This allows your SPA to load and take over routing on the client side.
+
 You can use `http.readStaticFile` or `http.node.readStaticFile` to serve the `index.html` page for all paths. For example, using Express:
 
 ```javascript
@@ -152,12 +160,25 @@ import express from "express"
 
 const app = express()
 
+// Define API routes FIRST, before the SPA fallback
 app.use('/api', ...)
 
+// SPA fallback: Return index.html for all other paths
 app.use(async (req, res) => {
-  // Return "static/index.html"
   res.status(200).set('Content-Type', 'text/html')
   const stream = await http.node.readStaticFile("index.html")
   return stream.pipe(res)
 })
+
+http.node.use(app)
 ```
+
+!!! caution
+**Critical for SPAs with routing:** This catch-all handler must come **after** your API routes. If placed before them, API requests will receive `index.html` instead of your API responses.
+!!!
+
+This ensures:
+- All SPA routes load correctly (including deep links and page refreshes)
+- API routes continue to work as expected
+- Static assets are served from the `/static` directory
+- Your client-side router takes control once the JavaScript loads


### PR DESCRIPTION
## Problem

The SPA fallback pattern using `readStaticFile` was buried at the bottom of the docs and not obvious. This pattern is **critical** for SPAs with client-side routing to work properly - without it, refreshing on nested routes or accessing deep links results in 404 errors.

Additionally, the code example had a bug: the function was missing the `async` keyword despite using `await`.

Fixes: https://linear.app/bens-personal-todos/issue/BEN-16

## Changes

### frameworks/spas.md
- **Fixed async bug** - Added `async` keyword to function
- **Renamed section** to "Configuring Client-Side Routing" (more descriptive)
- **Added problem explanation** before showing code - explains WHY this is needed
- **Added caution callout** - Emphasizes this is required for SPAs with routing
- **Added note callout** - Warns about API route ordering (must come before fallback)
- **Added benefits list** - Clear bullet points showing what the pattern ensures
- **Made it actionable** - Shows complete pattern with `http.node.use(app)`

### http.md
- **Enhanced SPA section** - Added "The SPA Routing Problem" and "The Solution" subsections
- **Added problem/solution structure** - Clear before/after explanation
- **Added caution callout** - Route ordering warning
- **Added benefits list** - Explains what the pattern ensures
- **Improved code comments** - More self-documenting

## Result

The critical `readStaticFile` pattern is now:
- **Impossible to miss** - Clear section title and prominent placement
- **Well-explained** - Developers understand the WHY, not just the HOW
- **Correct** - No syntax bugs
- **Actionable** - Complete working examples with warnings about common pitfalls

This should prevent confusion when setting up SPAs with client-side routing on Ampt.